### PR TITLE
Genome coverage estimation

### DIFF
--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -258,7 +258,7 @@ def main():
     print("total bases: " + str(total_bp))
     print("expected genome size: " + str(expectedGenomeSize))
     print("coverage: " + str(coverage))
-	print("")
+    print("")
     print("contamination: " + str(qcVerdicts["Multiple_Species_Contamination"]))
     print("same as the expected species: " + str(qcVerdicts["Same_As_Expected_Species"]))
     print("contains plasmids: " + str(qcVerdicts["FASTQ_Contains_Plasmids"]))

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -27,157 +27,157 @@ import configparser
 from parsers import result_parsers
 
 def execute(command, curDir):
-    process = subprocess.Popen(command, shell=False, cwd=curDir, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+	process = subprocess.Popen(command, shell=False, cwd=curDir, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    # Poll process for new output until finished
-    while True:
-        nextline = process.stdout.readline()
-        if nextline == '' and process.poll() is not None:
-            break
-        sys.stdout.write(nextline)
-        sys.stdout.flush()
+	# Poll process for new output until finished
+	while True:
+		nextline = process.stdout.readline()
+		if nextline == '' and process.poll() is not None:
+			break
+		sys.stdout.write(nextline)
+		sys.stdout.flush()
 
-    output = process.communicate()[0]
-    exitCode = process.returncode
+	output = process.communicate()[0]
+	exitCode = process.returncode
 
-    if (exitCode == 0):
-        return output
-    else:
-        raise subprocess.CalledProcessError(exitCode, command)
+	if (exitCode == 0):
+		return output
+	else:
+		raise subprocess.CalledProcessError(exitCode, command)
 
 def httpGetFile(url, filepath=""):
-    if (filepath == ""):
-        return urllib.request.urlretrieve(url)
-    else:
-        urllib.request.urlretrieve(url, filepath)
-        return True
+	if (filepath == ""):
+		return urllib.request.urlretrieve(url)
+	else:
+		urllib.request.urlretrieve(url, filepath)
+		return True
 
 def gunzip(inputpath="", outputpath=""):
-    if (outputpath == ""):
-        with gzip.open(inputpath, 'rb') as f:
-            gzContent = f.read()
-        return gzContent
-    else:
-        with gzip.open(inputpath, 'rb') as f:
-            gzContent = f.read()
-        with open(outputpath, 'wb') as out:
-            out.write(gzContent)
-        return True
+	if (outputpath == ""):
+		with gzip.open(inputpath, 'rb') as f:
+			gzContent = f.read()
+		return gzContent
+	else:
+		with gzip.open(inputpath, 'rb') as f:
+			gzContent = f.read()
+		with open(outputpath, 'wb') as out:
+			out.write(gzContent)
+		return True
 
 def main():
-    
-    config = configparser.ConfigParser()
-    config.read(os.path.dirname(os.path.realpath(sys.argv[0])) + '/config.ini')
-    
-    #parses some parameters
-    parser = optparse.OptionParser("Usage: %prog [options] arg1 arg2 ...")
-    parser.add_option("-i", "--id", dest="id", type="string", help="identifier of the isolate")    
-    parser.add_option("-f", "--forward", dest="R1", type="string", help="absolute file path forward read (R1)")
-    parser.add_option("-r", "--reverse", dest="R2", type="string", help="absolute file path to reverse read (R2)")
-    parser.add_option("-m", "--mash-genomedb", dest="mashGenomeRefDB", default = config['databases']['mash-genomedb'], type="string", help="absolute path to mash reference database")
-    parser.add_option("-n", "--mash-plasmiddb", dest="mashPlasmidRefDB", default = config['databases']['mash-plasmiddb'], type="string", help="absolute path to mash reference database")
-    parser.add_option("-z", "--kraken2-genomedb", dest="kraken2GenomeRefDB", default = config['databases']['kraken2-genomedb'], type="string", help="absolute path to kraken reference database")
-    parser.add_option("-v", "--kraken2-plasmiddb", dest="kraken2PlasmidRefDB", default = config['databases']['kraken2-plasmiddb'], type="string", help="absolute path to kraken reference database")
-    parser.add_option("-x", "--busco-db", dest="buscodb", default = config['databases']['busco-db'], type="string", help="absolute path to busco reference database")
-
-    parser.add_option("-o", "--output", dest="output", default='./', type="string", help="absolute path to output folder")
-    parser.add_option("-k", "--script-path", dest="scriptDir", default=config['scripts']['script-path'], type="string", help="absolute file path to this script folder")
-
-    #used for parsing 
-    parser.add_option("-e", "--expected", dest="expectedSpecies", default="NA/NA/NA", type="string", help="expected species of the isolate")
-    
-    #parallelization, useless, these are hard coded to 8cores/64G RAM
-    #parser.add_option("-t", "--threads", dest="threads", default=8, type="int", help="number of cpu to use")
-    #parser.add_option("-p", "--memory", dest="memory", default=64, type="int", help="memory to use in GB")
-
-    (options,args) = parser.parse_args()
-
-    curDir = os.getcwd()
-    outputDir = options.output
-    mashdb = options.mashGenomeRefDB
-    mashplasmiddb=options.mashPlasmidRefDB
-    kraken2db = options.kraken2GenomeRefDB
-    kraken2plasmiddb=options.kraken2PlasmidRefDB
-    expectedSpecies = options.expectedSpecies
-    #threads = options.threads
-    #memory = options.memory
-    tempDir = outputDir + "/shovillTemp"
-    scriptDir = options.scriptDir
-    buscodb = options.buscodb
-    ID = options.id
-    R1 = options.R1
-    R2 = options.R2
-
-    
-    notes = []
-    #init the output list
-    output = []
-    
-    print(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
-    output.append(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
-
-    print("step 1: preassembly QC")
-
-    print("running pipeline_qc.sh")
-    #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=mashgenomerefdb, $6=mashplasmidrefdb, $7=kraken2db, $8=kraken2plasmiddb
-    cmd = [scriptDir + "/pipeline_qc.sh", ID, R1, R2, outputDir, mashdb, mashplasmiddb, kraken2db, kraken2plasmiddb]
-    result = execute(cmd, curDir)
-
-    print("Parsing the QC results")
 	
-    #parse read stats
-    '''
+	config = configparser.ConfigParser()
+	config.read(os.path.dirname(os.path.realpath(sys.argv[0])) + '/config.ini')
+	
+	#parses some parameters
+	parser = optparse.OptionParser("Usage: %prog [options] arg1 arg2 ...")
+	parser.add_option("-i", "--id", dest="id", type="string", help="identifier of the isolate")	
+	parser.add_option("-f", "--forward", dest="R1", type="string", help="absolute file path forward read (R1)")
+	parser.add_option("-r", "--reverse", dest="R2", type="string", help="absolute file path to reverse read (R2)")
+	parser.add_option("-m", "--mash-genomedb", dest="mashGenomeRefDB", default = config['databases']['mash-genomedb'], type="string", help="absolute path to mash reference database")
+	parser.add_option("-n", "--mash-plasmiddb", dest="mashPlasmidRefDB", default = config['databases']['mash-plasmiddb'], type="string", help="absolute path to mash reference database")
+	parser.add_option("-z", "--kraken2-genomedb", dest="kraken2GenomeRefDB", default = config['databases']['kraken2-genomedb'], type="string", help="absolute path to kraken reference database")
+	parser.add_option("-v", "--kraken2-plasmiddb", dest="kraken2PlasmidRefDB", default = config['databases']['kraken2-plasmiddb'], type="string", help="absolute path to kraken reference database")
+	parser.add_option("-x", "--busco-db", dest="buscodb", default = config['databases']['busco-db'], type="string", help="absolute path to busco reference database")
+
+	parser.add_option("-o", "--output", dest="output", default='./', type="string", help="absolute path to output folder")
+	parser.add_option("-k", "--script-path", dest="scriptDir", default=config['scripts']['script-path'], type="string", help="absolute file path to this script folder")
+
+	#used for parsing 
+	parser.add_option("-e", "--expected", dest="expectedSpecies", default="NA/NA/NA", type="string", help="expected species of the isolate")
+	
+	#parallelization, useless, these are hard coded to 8cores/64G RAM
+	#parser.add_option("-t", "--threads", dest="threads", default=8, type="int", help="number of cpu to use")
+	#parser.add_option("-p", "--memory", dest="memory", default=64, type="int", help="memory to use in GB")
+
+	(options,args) = parser.parse_args()
+
+	curDir = os.getcwd()
+	outputDir = options.output
+	mashdb = options.mashGenomeRefDB
+	mashplasmiddb=options.mashPlasmidRefDB
+	kraken2db = options.kraken2GenomeRefDB
+	kraken2plasmiddb=options.kraken2PlasmidRefDB
+	expectedSpecies = options.expectedSpecies
+	#threads = options.threads
+	#memory = options.memory
+	tempDir = outputDir + "/shovillTemp"
+	scriptDir = options.scriptDir
+	buscodb = options.buscodb
+	ID = options.id
+	R1 = options.R1
+	R2 = options.R2
+
+	
+	notes = []
+	#init the output list
+	output = []
+	
+	print(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
+	output.append(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
+
+	print("step 1: preassembly QC")
+
+	print("running pipeline_qc.sh")
+	#input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=mashgenomerefdb, $6=mashplasmidrefdb, $7=kraken2db, $8=kraken2plasmiddb
+	cmd = [scriptDir + "/pipeline_qc.sh", ID, R1, R2, outputDir, mashdb, mashplasmiddb, kraken2db, kraken2plasmiddb]
+	result = execute(cmd, curDir)
+
+	print("Parsing the QC results")
+	
+	#parse read stats
+	'''
 	pathToMashLog = outputDir + "/qcResult/" + ID + "/" + "mash.log"
-    pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
-    stats = result_parsers.parse_read_stats(pathToMashLog, pathToTotalBP)
+	pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
+	stats = result_parsers.parse_read_stats(pathToMashLog, pathToTotalBP)
 	'''
 	
-    #parse genome mash results
-    pathToMashGenomeScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.genome.tsv"
-    mash_hits = result_parsers.parse_mash_result(pathToMashGenomeScreenTSV)
+	#parse genome mash results
+	pathToMashGenomeScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.genome.tsv"
+	mash_hits = result_parsers.parse_mash_result(pathToMashGenomeScreenTSV)
 
-    # 'shared_hashes' field is string in format '935/1000'
-    # Threshold is 300 below highest numerator (ie. '935/100' -> 635)
-    mash_hits_score_threshold = int(mash_hits[0]['shared_hashes'].split("/")[0]) - 300
-    print("*** mash_hits_score_threshold: " + str(mash_hits_score_threshold))
-    def score_above_threshold(mash_result, score_threshold):
-        score = int(mash_result['shared_hashes'].split("/")[0])
-        if score >= score_threshold:
-            return True
-        else:
-            return False
-        
-    filtered_mash_hits = list(filter(
-        lambda x: score_above_threshold(x, mash_hits_score_threshold),
-        mash_hits))
-    
-    # parse plasmid mash
-    pathToMashPlasmidScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.plasmid.tsv"
-    mash_plasmid_hits = result_parsers.parse_mash_result(pathToMashPlasmidScreenTSV)
-    # 'shared_hashes' field is string in format '935/1000'
-    # Threshold is 100 below highest numerator (ie. '935/100' -> 835)
-    mash_plasmid_hits_score_threshold = int(mash_plasmid_hits[0]['shared_hashes'].split("/")[0]) - 100
-    filtered_mash_plasmid_hits = list(filter(
-        lambda x: score_above_threshold(x, mash_plasmid_hits_score_threshold),
-        mash_plasmid_hits))
-    
-    # parse fastqc
-    pathToFastQCR1 = outputDir + "/qcResult/" + ID + "/" + R1[R1.find(os.path.basename(R1)):R1.find(".")] + "_fastqc/summary.txt"
-    pathToFastQCR2 = outputDir + "/qcResult/" + ID + "/" + R2[R2.find(os.path.basename(R2)):R2.find(".")] + "_fastqc/summary.txt"
-    fastqcR1 = result_parsers.parse_fastqc_result(pathToFastQCR1)
-    fastqcR2 = result_parsers.parse_fastqc_result(pathToFastQCR2)
-    fastqc = {}
-    fastqc["R1"]=fastqcR1
-    fastqc["R2"]=fastqcR2
-     
-    #parse kraken2 result
+	# 'shared_hashes' field is string in format '935/1000'
+	# Threshold is 300 below highest numerator (ie. '935/100' -> 635)
+	mash_hits_score_threshold = int(mash_hits[0]['shared_hashes'].split("/")[0]) - 300
+	print("*** mash_hits_score_threshold: " + str(mash_hits_score_threshold))
+	def score_above_threshold(mash_result, score_threshold):
+		score = int(mash_result['shared_hashes'].split("/")[0])
+		if score >= score_threshold:
+			return True
+		else:
+			return False
+		
+	filtered_mash_hits = list(filter(
+		lambda x: score_above_threshold(x, mash_hits_score_threshold),
+		mash_hits))
+	
+	# parse plasmid mash
+	pathToMashPlasmidScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.plasmid.tsv"
+	mash_plasmid_hits = result_parsers.parse_mash_result(pathToMashPlasmidScreenTSV)
+	# 'shared_hashes' field is string in format '935/1000'
+	# Threshold is 100 below highest numerator (ie. '935/100' -> 835)
+	mash_plasmid_hits_score_threshold = int(mash_plasmid_hits[0]['shared_hashes'].split("/")[0]) - 100
+	filtered_mash_plasmid_hits = list(filter(
+		lambda x: score_above_threshold(x, mash_plasmid_hits_score_threshold),
+		mash_plasmid_hits))
+	
+	# parse fastqc
+	pathToFastQCR1 = outputDir + "/qcResult/" + ID + "/" + R1[R1.find(os.path.basename(R1)):R1.find(".")] + "_fastqc/summary.txt"
+	pathToFastQCR2 = outputDir + "/qcResult/" + ID + "/" + R2[R2.find(os.path.basename(R2)):R2.find(".")] + "_fastqc/summary.txt"
+	fastqcR1 = result_parsers.parse_fastqc_result(pathToFastQCR1)
+	fastqcR2 = result_parsers.parse_fastqc_result(pathToFastQCR2)
+	fastqc = {}
+	fastqc["R1"]=fastqcR1
+	fastqc["R2"]=fastqcR2
+	 
+	#parse kraken2 result
 	#pathToKrakenResult = outputDir + "/qcResult/" + ID + "/kraken2.genome.report"
-    #kraken_genomes = result_parsers.parse_kraken_result(pathToKrakenResult)
+	#kraken_genomes = result_parsers.parse_kraken_result(pathToKrakenResult)
 
 	
 
 	multipleSpecies = False
-    correctSpecies = False
+	correctSpecies = False
 	containsPlasmid = False
 	acceptableCoverage = False
 	acceptableFastQCForward = False
@@ -186,27 +186,27 @@ def main():
 	#all the qC result are parsed now, lets do some QC logic
 	#look at mash results first
 	if (len(filtered_mash_hits) > 1):
-        multipleSpecies = True
+		multipleSpecies = True
 	
 	for mash_hit in filtered_mash_hits:
-        species = mash_hit['query_comment']
-        if (species.find(expectedSpecies) > -1):
-            correctSpecies=True
+		species = mash_hit['query_comment']
+		if (species.find(expectedSpecies) > -1):
+			correctSpecies=True
 	
 	if (len(filtered_mash_plasmid_hits) > 0):
 		containsPlasmid = True
-    #look at kraken results > Removed, simplified to using only mash. Validation with Kraken2 is no longer required as we are no longer doing contamination filtering.
+	#look at kraken results > Removed, simplified to using only mash. Validation with Kraken2 is no longer required as we are no longer doing contamination filtering.
 	# TODO: filter kraken_genomes based on contamination thresholds
-    # if (len(kraken_genomes) > 1):
-    #     output.append("!!!Kraken2 predicted multiple species, possible contamination?")
-    #     notes.append("Kraken2: multiple species, possible contamination.")
-    #     #multipleSpecies = True
-    # elif (len(kraken_genomes) == 1):
-    #     multipleSpecies = False
-        
-    #for kraken_genome in  kraken_genomes:
-    #    if (kraken_genome['taxon_name'] == expectedSpecies):
-    #        correctSpecies = True
+	# if (len(kraken_genomes) > 1):
+	#	 output.append("!!!Kraken2 predicted multiple species, possible contamination?")
+	#	 notes.append("Kraken2: multiple species, possible contamination.")
+	#	 #multipleSpecies = True
+	# elif (len(kraken_genomes) == 1):
+	#	 multipleSpecies = False
+		
+	#for kraken_genome in  kraken_genomes:
+	#	if (kraken_genome['taxon_name'] == expectedSpecies):
+	#		correctSpecies = True
 
 	#look at fastqc results
   
@@ -249,7 +249,7 @@ def main():
 				os.remove(referencePath + ".gz")
 	else: #throw an error if it contains contaminations
 		print("Contaminated Genome assembly...resequencing required")
-        raise Exception("contamination and mislabeling...crashing")
+		raise Exception("contamination and mislabeling...crashing")
 		
 	#check to make sure we ONLY have ONE reference.
 	if (len(referenceGenomes) > 1 ):
@@ -267,9 +267,9 @@ def main():
 			expectedGenomeSize = float(s.split("\t")[5].strip()) 
 
 	#find total base count
-    pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
+	pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
 	with open(pathToTotalBP, 'r') as totalbp_file:
-        total_bp = float(totalbp_file.readline())
+		total_bp = float(totalbp_file.readline())
 	
 	#calculate coverage
 	coverage = total_bp / expectedGenomeSize
@@ -285,174 +285,174 @@ def main():
 	print(str(acceptableFastQCReverse))
 
 	
-    print("Formatting the QC results")
+	print("Formatting the QC results")
 
-    output.append("\n\n~~~~~~~QC summary~~~~~~~")
-    output.append("Estimated genome size: " + str(stats['estimated_genome_size']))
-    output.append("Estimated coverage: " + str(stats['estimated_depth_of_coverage']))
-    output.append("Expected isolate species: " + expectedSpecies)
+	output.append("\n\n~~~~~~~QC summary~~~~~~~")
+	output.append("Estimated genome size: " + str(stats['estimated_genome_size']))
+	output.append("Estimated coverage: " + str(stats['estimated_depth_of_coverage']))
+	output.append("Expected isolate species: " + expectedSpecies)
 
-    output.append("\nFastQC summary:")
-    output.append("\nforward read qc:")
-    for key, value in fastqcR1.items():
-        output.append(key + ": " + value)
-        if (value == "WARN" or value == "FAIL"):
-            notes.append("FastQC: Forward read, " + key + " " + value)
+	output.append("\nFastQC summary:")
+	output.append("\nforward read qc:")
+	for key, value in fastqcR1.items():
+		output.append(key + ": " + value)
+		if (value == "WARN" or value == "FAIL"):
+			notes.append("FastQC: Forward read, " + key + " " + value)
 
-    output.append("\nreverse read qc:")
-    for key, value in fastqcR2.items():
-        output.append(key + ": " + value)
-        if (value == "WARN" or value == "FAIL"):
-            notes.append("FastQC: Reverse read, " + key + " " + value)
+	output.append("\nreverse read qc:")
+	for key, value in fastqcR2.items():
+		output.append(key + ": " + value)
+		if (value == "WARN" or value == "FAIL"):
+			notes.append("FastQC: Reverse read, " + key + " " + value)
 
-    output.append("\nKraken2 predicted species (>1%): ")
-    for kraken_genome in kraken_genomes:
-        # TODO filter by species and percentage
-        output.append(kraken_genome['taxon_name'])
+	output.append("\nKraken2 predicted species (>1%): ")
+	for kraken_genome in kraken_genomes:
+		# TODO filter by species and percentage
+		output.append(kraken_genome['taxon_name'])
 
-    output.append("\nmash predicted genomes")
-    for mash_hit in filtered_mash_hits:
-        output.append(mash_hit['query_comment'])
+	output.append("\nmash predicted genomes")
+	for mash_hit in filtered_mash_hits:
+		output.append(mash_hit['query_comment'])
 
-    output.append("\nmash predicted plasmids")
-    for mash_plasmid_hit in mash_plasmid_hits:
-        output.append(mash_plasmid_hit['query_comment'])
-    
-    output.append("\nDetailed kraken genome hits: ")
-    for kraken_genome in kraken_genomes:
-        output.append(
-            str(kraken_genome['fragment_percent']) + '\t' +
-            str(kraken_genome['fragment_count_root']) + '\t' +
-            str(kraken_genome['fragment_count_taxon']) + '\t' +
-            kraken_genome['rank_code'] + '\t' +
-            kraken_genome['ncbi_taxon_id'] + '\t' +
-            kraken_genome['taxon_name']
-        )
+	output.append("\nmash predicted plasmids")
+	for mash_plasmid_hit in mash_plasmid_hits:
+		output.append(mash_plasmid_hit['query_comment'])
+	
+	output.append("\nDetailed kraken genome hits: ")
+	for kraken_genome in kraken_genomes:
+		output.append(
+			str(kraken_genome['fragment_percent']) + '\t' +
+			str(kraken_genome['fragment_count_root']) + '\t' +
+			str(kraken_genome['fragment_count_taxon']) + '\t' +
+			kraken_genome['rank_code'] + '\t' +
+			kraken_genome['ncbi_taxon_id'] + '\t' +
+			kraken_genome['taxon_name']
+		)
 
-    output.append("\nDetailed mash genome hits: ")
-    for mash_hit in mash_hits:
-        output.append(
-            str(mash_hit['identity']) + '\t' +
-            mash_hit['shared_hashes'] + '\t' +
-            str(mash_hit['median_multiplicity']) + '\t' +
-            str(mash_hit['p_value']) + '\t' +
-            mash_hit['query_id'] + '\t' +
-            mash_hit['query_comment']
-        )
-    
-    output.append("\nDetailed mash plasmid hits: ")
-    for mash_plasmid_hit in mash_plasmid_hits:
-        output.append(
-            str(mash_plasmid_hit['identity']) + '\t' +
-            mash_plasmid_hit['shared_hashes'] + '\t' +
-            str(mash_plasmid_hit['median_multiplicity']) + '\t' +
-            str(mash_plasmid_hit['p_value']) + '\t' +
-            mash_plasmid_hit['query_id'] + '\t' +
-            mash_plasmid_hit['query_comment']
-        )
+	output.append("\nDetailed mash genome hits: ")
+	for mash_hit in mash_hits:
+		output.append(
+			str(mash_hit['identity']) + '\t' +
+			mash_hit['shared_hashes'] + '\t' +
+			str(mash_hit['median_multiplicity']) + '\t' +
+			str(mash_hit['p_value']) + '\t' +
+			mash_hit['query_id'] + '\t' +
+			mash_hit['query_comment']
+		)
+	
+	output.append("\nDetailed mash plasmid hits: ")
+	for mash_plasmid_hit in mash_plasmid_hits:
+		output.append(
+			str(mash_plasmid_hit['identity']) + '\t' +
+			mash_plasmid_hit['shared_hashes'] + '\t' +
+			str(mash_plasmid_hit['median_multiplicity']) + '\t' +
+			str(mash_plasmid_hit['p_value']) + '\t' +
+			mash_plasmid_hit['query_id'] + '\t' +
+			mash_plasmid_hit['query_comment']
+		)
 
-    #qcsummary
-    output.append("\n\nQC Information:")
+	#qcsummary
+	output.append("\n\nQC Information:")
 
 
 	'''
-    if present:
-        output.append("The expected species is predicted by kraken 2")
-        #correctSpecies = True
-    else:
-        output.append("!!!The expected species is NOT predicted by kraken2, contamination? mislabeling?")
-        notes.append("Kraken2: Not expected species. Possible contamination or mislabeling")
+	if present:
+		output.append("The expected species is predicted by kraken 2")
+		#correctSpecies = True
+	else:
+		output.append("!!!The expected species is NOT predicted by kraken2, contamination? mislabeling?")
+		notes.append("Kraken2: Not expected species. Possible contamination or mislabeling")
 	
-    if (stats['estimated_depth_of_coverage'] < 30):
-        output.append("!!!Coverage is lower than 30. Estimated depth: " + str(stats['estimated_depth_of_coverage']))
+	if (stats['estimated_depth_of_coverage'] < 30):
+		output.append("!!!Coverage is lower than 30. Estimated depth: " + str(stats['estimated_depth_of_coverage']))
 	
 	
-    if (len(filtered_mash_hits) > 1):
-        output.append("!!!MASH predicted multiple species, possible contamination?")
-        multipleSpecies = True
-    elif (len(filtered_mash_hits) < 1):
-        output.append("!!!MASH had no hits, this is an unknown species")
-        notes.append("Mash: Unknown Species")
-    '''
+	if (len(filtered_mash_hits) > 1):
+		output.append("!!!MASH predicted multiple species, possible contamination?")
+		multipleSpecies = True
+	elif (len(filtered_mash_hits) < 1):
+		output.append("!!!MASH had no hits, this is an unknown species")
+		notes.append("Mash: Unknown Species")
 	'''
-    present=False
-    for mash_hit in filtered_mash_hits:
-        species = mash_hit['query_comment']
-        if (species.find(expectedSpecies) > -1):
-            present=True
+	'''
+	present=False
+	for mash_hit in filtered_mash_hits:
+		species = mash_hit['query_comment']
+		if (species.find(expectedSpecies) > -1):
+			present=True
 	
-    if present:
-        output.append("The expected species is predicted by mash")
-        correctSpecies = True
-        #notes.append("The expected species is predicted by mash")
-    else:
-        output.append("!!!The expected species is NOT predicted by mash, poor resolution? contamination? mislabeling?")
-        notes.append("Mash: Not expected species. Possible resolution issues, contamination or mislabeling")
+	if present:
+		output.append("The expected species is predicted by mash")
+		correctSpecies = True
+		#notes.append("The expected species is predicted by mash")
+	else:
+		output.append("!!!The expected species is NOT predicted by mash, poor resolution? contamination? mislabeling?")
+		notes.append("Mash: Not expected species. Possible resolution issues, contamination or mislabeling")
 
-    if (len(mash_plasmid_hits) == 0):
-        output.append("!!!no plasmids predicted")
-        notes.append("Mash: no plasmid predicted")
+	if (len(mash_plasmid_hits) == 0):
+		output.append("!!!no plasmids predicted")
+		notes.append("Mash: no plasmid predicted")
 
-    #hack: throw exception if this analysis should not proceed due to contamination and mislabelling
-    #if (multipleSpecies and not correctSpecies):
-    #    out = open(outputDir + "/summary/" + ID +".err", 'a')
-    #    out.write('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
-    #    #raise Exception('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
-    
+	#hack: throw exception if this analysis should not proceed due to contamination and mislabelling
+	#if (multipleSpecies and not correctSpecies):
+	#	out = open(outputDir + "/summary/" + ID +".err", 'a')
+	#	out.write('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
+	#	#raise Exception('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
+	
 	#identify and download reference genomes, this should only return one reference.
 	'''
 	
 	'''
-    correctReference = ""
-    if (len(referenceGenomes) > 1):
-        for item in referenceGenomes:
-            if (item.find(expectedSpecies.replace(" ", "")) > -1): #found the right genome
-                correctReference = os.path.basename(item)
-    else:
-        correctReference = os.path.basename(referenceGenomes[0])
+	correctReference = ""
+	if (len(referenceGenomes) > 1):
+		for item in referenceGenomes:
+			if (item.find(expectedSpecies.replace(" ", "")) > -1): #found the right genome
+				correctReference = os.path.basename(item)
+	else:
+		correctReference = os.path.basename(referenceGenomes[0])
 		
-    if (correctReference == ""):
-        raise Exception("no reference genome...crashing")
-    '''
+	if (correctReference == ""):
+		raise Exception("no reference genome...crashing")
+	'''
 	print("step 2: genome assembly and QC")
 
 	#run the assembly shell script.
 	#input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=tmpdir for shovill, 6=reference genome, 7=buscoDB
 	cmd = [scriptDir + "/pipeline_assembly.sh", ID, R1, R2, outputDir, tempDir, referenceGenomes[0], buscodb]
 	result = execute(cmd, curDir)
-    
-    print("Parsing assembly results")
-    #get the correct busco and quast result file to parse
+	
+	print("Parsing assembly results")
+	#get the correct busco and quast result file to parse
 	
 	'''
-    correctAssembly = ""
-    buscoPath = "" 
-    quastPath = ""
-    if ((not multiple and correctSpecies) or (not multiple and not correctSpecies)): #only 1 reference genome
-        buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".busco" + "/short_summary_" + ID + ".busco.txt")
-        quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
-        correctAssembly = ID
-    elif(multiple and correctSpecies): #multiple reference genome, need to find the one we care about
-        for item in referenceGenomes:
-            if (item.find(expectedSpecies.replace(" ", "")) > -1): #found the right genome
-                buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + "." + os.path.basename(item) + ".busco" + "/short_summary_" + ID + "." + os.path.basename(item) + ".busco.txt")
-                quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + "." + os.path.basename(item) + ".quast/runs_per_reference/" + os.path.basename(item) + "/report.tsv")
-                correctAssembly = ID + "." + os.path.basename(item)
-    elif(multiple and not correctSpecies):
-        raise Exception('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
+	correctAssembly = ""
+	buscoPath = "" 
+	quastPath = ""
+	if ((not multiple and correctSpecies) or (not multiple and not correctSpecies)): #only 1 reference genome
+		buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".busco" + "/short_summary_" + ID + ".busco.txt")
+		quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
+		correctAssembly = ID
+	elif(multiple and correctSpecies): #multiple reference genome, need to find the one we care about
+		for item in referenceGenomes:
+			if (item.find(expectedSpecies.replace(" ", "")) > -1): #found the right genome
+				buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + "." + os.path.basename(item) + ".busco" + "/short_summary_" + ID + "." + os.path.basename(item) + ".busco.txt")
+				quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + "." + os.path.basename(item) + ".quast/runs_per_reference/" + os.path.basename(item) + "/report.tsv")
+				correctAssembly = ID + "." + os.path.basename(item)
+	elif(multiple and not correctSpecies):
+		raise Exception('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
 
-    if (buscoPath == "" or quastPath == ""):
-        raise Exception('theres no reference genome for this sample for whatever reason...')
+	if (buscoPath == "" or quastPath == ""):
+		raise Exception('theres no reference genome for this sample for whatever reason...')
 	'''
 	buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".busco" + "/short_summary_" + ID + ".busco.txt")
 	quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
-    #populate the busco and quast result object
-    buscoResults = result_parsers.parse_busco_result(buscoPath)
-    quastResults = result_parsers.parse_busco_result(quastPath)
+	#populate the busco and quast result object
+	buscoResults = result_parsers.parse_busco_result(buscoPath)
+	quastResults = result_parsers.parse_busco_result(quastPath)
 
 if __name__ == "__main__":
-    start = time.time()
-    print("Starting workflow...")
-    main()
-    end = time.time()
-    print("Finished!\nThe analysis used: " + str(end - start) + " seconds")
+	start = time.time()
+	print("Starting workflow...")
+	main()
+	end = time.time()
+	print("Finished!\nThe analysis used: " + str(end - start) + " seconds")

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -294,11 +294,6 @@ def main():
 		if (value == "WARN" or value == "FAIL"):
 			notes.append("FastQC: Reverse read, " + key + " " + value)
 
-	output.append("\nKraken2 predicted species (>1%): ")
-	for kraken_genome in kraken_genomes:
-		# TODO filter by species and percentage
-		output.append(kraken_genome['taxon_name'])
-
 	output.append("\nmash predicted genomes")
 	for mash_hit in filtered_mash_hits:
 		output.append(mash_hit['query_comment'])
@@ -307,16 +302,6 @@ def main():
 	for mash_plasmid_hit in mash_plasmid_hits:
 		output.append(mash_plasmid_hit['query_comment'])
 	
-	output.append("\nDetailed kraken genome hits: ")
-	for kraken_genome in kraken_genomes:
-		output.append(
-			str(kraken_genome['fragment_percent']) + '\t' +
-			str(kraken_genome['fragment_count_root']) + '\t' +
-			str(kraken_genome['fragment_count_taxon']) + '\t' +
-			kraken_genome['rank_code'] + '\t' +
-			kraken_genome['ncbi_taxon_id'] + '\t' +
-			kraken_genome['taxon_name']
-		)
 
 	output.append("\nDetailed mash genome hits: ")
 	for mash_hit in mash_hits:

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -27,326 +27,326 @@ import configparser
 from parsers import result_parsers
 
 def execute(command, curDir):
-	process = subprocess.Popen(command, shell=False, cwd=curDir, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    process = subprocess.Popen(command, shell=False, cwd=curDir, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-	# Poll process for new output until finished
-	while True:
-		nextline = process.stdout.readline()
-		if nextline == '' and process.poll() is not None:
-			break
-		sys.stdout.write(nextline)
-		sys.stdout.flush()
+    # Poll process for new output until finished
+    while True:
+        nextline = process.stdout.readline()
+        if nextline == '' and process.poll() is not None:
+            break
+        sys.stdout.write(nextline)
+        sys.stdout.flush()
 
-	output = process.communicate()[0]
-	exitCode = process.returncode
+    output = process.communicate()[0]
+    exitCode = process.returncode
 
-	if (exitCode == 0):
-		return output
-	else:
-		raise subprocess.CalledProcessError(exitCode, command)
+    if (exitCode == 0):
+        return output
+    else:
+        raise subprocess.CalledProcessError(exitCode, command)
 
 def httpGetFile(url, filepath=""):
-	if (filepath == ""):
-		return urllib.request.urlretrieve(url)
-	else:
-		urllib.request.urlretrieve(url, filepath)
-		return True
+    if (filepath == ""):
+        return urllib.request.urlretrieve(url)
+    else:
+        urllib.request.urlretrieve(url, filepath)
+        return True
 
 def gunzip(inputpath="", outputpath=""):
-	if (outputpath == ""):
-		with gzip.open(inputpath, 'rb') as f:
-			gzContent = f.read()
-		return gzContent
-	else:
-		with gzip.open(inputpath, 'rb') as f:
-			gzContent = f.read()
-		with open(outputpath, 'wb') as out:
-			out.write(gzContent)
-		return True
+    if (outputpath == ""):
+        with gzip.open(inputpath, 'rb') as f:
+            gzContent = f.read()
+        return gzContent
+    else:
+        with gzip.open(inputpath, 'rb') as f:
+            gzContent = f.read()
+        with open(outputpath, 'wb') as out:
+            out.write(gzContent)
+        return True
 
 def main():
-	
-	config = configparser.ConfigParser()
-	config.read(os.path.dirname(os.path.realpath(sys.argv[0])) + '/config.ini')
-	
-	#parses some parameters
-	parser = optparse.OptionParser("Usage: %prog [options] arg1 arg2 ...")
-	parser.add_option("-i", "--id", dest="id", type="string", help="identifier of the isolate")	
-	parser.add_option("-f", "--forward", dest="R1", type="string", help="absolute file path forward read (R1)")
-	parser.add_option("-r", "--reverse", dest="R2", type="string", help="absolute file path to reverse read (R2)")
-	parser.add_option("-m", "--mash-genomedb", dest="mashGenomeRefDB", default = config['databases']['mash-genomedb'], type="string", help="absolute path to mash reference database")
-	parser.add_option("-n", "--mash-plasmiddb", dest="mashPlasmidRefDB", default = config['databases']['mash-plasmiddb'], type="string", help="absolute path to mash reference database")
-	parser.add_option("-z", "--kraken2-genomedb", dest="kraken2GenomeRefDB", default = config['databases']['kraken2-genomedb'], type="string", help="absolute path to kraken reference database")
-	parser.add_option("-v", "--kraken2-plasmiddb", dest="kraken2PlasmidRefDB", default = config['databases']['kraken2-plasmiddb'], type="string", help="absolute path to kraken reference database")
-	parser.add_option("-x", "--busco-db", dest="buscodb", default = config['databases']['busco-db'], type="string", help="absolute path to busco reference database")
+    
+    config = configparser.ConfigParser()
+    config.read(os.path.dirname(os.path.realpath(sys.argv[0])) + '/config.ini')
+    
+    #parses some parameters
+    parser = optparse.OptionParser("Usage: %prog [options] arg1 arg2 ...")
+    parser.add_option("-i", "--id", dest="id", type="string", help="identifier of the isolate")    
+    parser.add_option("-f", "--forward", dest="R1", type="string", help="absolute file path forward read (R1)")
+    parser.add_option("-r", "--reverse", dest="R2", type="string", help="absolute file path to reverse read (R2)")
+    parser.add_option("-m", "--mash-genomedb", dest="mashGenomeRefDB", default = config['databases']['mash-genomedb'], type="string", help="absolute path to mash reference database")
+    parser.add_option("-n", "--mash-plasmiddb", dest="mashPlasmidRefDB", default = config['databases']['mash-plasmiddb'], type="string", help="absolute path to mash reference database")
+    parser.add_option("-z", "--kraken2-genomedb", dest="kraken2GenomeRefDB", default = config['databases']['kraken2-genomedb'], type="string", help="absolute path to kraken reference database")
+    parser.add_option("-v", "--kraken2-plasmiddb", dest="kraken2PlasmidRefDB", default = config['databases']['kraken2-plasmiddb'], type="string", help="absolute path to kraken reference database")
+    parser.add_option("-x", "--busco-db", dest="buscodb", default = config['databases']['busco-db'], type="string", help="absolute path to busco reference database")
 
-	parser.add_option("-o", "--output", dest="output", default='./', type="string", help="absolute path to output folder")
-	parser.add_option("-k", "--script-path", dest="scriptDir", default=config['scripts']['script-path'], type="string", help="absolute file path to this script folder")
+    parser.add_option("-o", "--output", dest="output", default='./', type="string", help="absolute path to output folder")
+    parser.add_option("-k", "--script-path", dest="scriptDir", default=config['scripts']['script-path'], type="string", help="absolute file path to this script folder")
 
-	#used for parsing 
-	parser.add_option("-e", "--expected", dest="expectedSpecies", default="NA/NA/NA", type="string", help="expected species of the isolate")
-	
-	#parallelization, useless, these are hard coded to 8cores/64G RAM
-	#parser.add_option("-t", "--threads", dest="threads", default=8, type="int", help="number of cpu to use")
-	#parser.add_option("-p", "--memory", dest="memory", default=64, type="int", help="memory to use in GB")
+    #used for parsing 
+    parser.add_option("-e", "--expected", dest="expectedSpecies", default="NA/NA/NA", type="string", help="expected species of the isolate")
+    
+    #parallelization, useless, these are hard coded to 8cores/64G RAM
+    #parser.add_option("-t", "--threads", dest="threads", default=8, type="int", help="number of cpu to use")
+    #parser.add_option("-p", "--memory", dest="memory", default=64, type="int", help="memory to use in GB")
 
-	(options,args) = parser.parse_args()
+    (options,args) = parser.parse_args()
 
-	curDir = os.getcwd()
-	outputDir = options.output
-	mashdb = options.mashGenomeRefDB
-	mashplasmiddb=options.mashPlasmidRefDB
-	kraken2db = options.kraken2GenomeRefDB
-	kraken2plasmiddb=options.kraken2PlasmidRefDB
-	expectedSpecies = options.expectedSpecies
-	#threads = options.threads
-	#memory = options.memory
-	tempDir = outputDir + "/shovillTemp"
-	scriptDir = options.scriptDir
-	buscodb = options.buscodb
-	ID = options.id
-	R1 = options.R1
-	R2 = options.R2
+    curDir = os.getcwd()
+    outputDir = options.output
+    mashdb = options.mashGenomeRefDB
+    mashplasmiddb=options.mashPlasmidRefDB
+    kraken2db = options.kraken2GenomeRefDB
+    kraken2plasmiddb=options.kraken2PlasmidRefDB
+    expectedSpecies = options.expectedSpecies
+    #threads = options.threads
+    #memory = options.memory
+    tempDir = outputDir + "/shovillTemp"
+    scriptDir = options.scriptDir
+    buscodb = options.buscodb
+    ID = options.id
+    R1 = options.R1
+    R2 = options.R2
 
-	
-	notes = []
-	#init the output list
-	output = []
-	
-	print(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
-	output.append(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
+    
+    notes = []
+    #init the output list
+    output = []
+    
+    print(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
+    output.append(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)
 
-	print("step 1: preassembly QC")
+    print("step 1: preassembly QC")
 
-	print("running pipeline_qc.sh")
-	#input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=mashgenomerefdb, $6=mashplasmidrefdb, $7=kraken2db, $8=kraken2plasmiddb
-	cmd = [scriptDir + "/pipeline_qc.sh", ID, R1, R2, outputDir, mashdb, mashplasmiddb, kraken2db, kraken2plasmiddb]
-	result = execute(cmd, curDir)
+    print("running pipeline_qc.sh")
+    #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=mashgenomerefdb, $6=mashplasmidrefdb, $7=kraken2db, $8=kraken2plasmiddb
+    cmd = [scriptDir + "/pipeline_qc.sh", ID, R1, R2, outputDir, mashdb, mashplasmiddb, kraken2db, kraken2plasmiddb]
+    result = execute(cmd, curDir)
 
-	print("Parsing the QC results")
-	
-	#parse read stats
-	'''
-	pathToMashLog = outputDir + "/qcResult/" + ID + "/" + "mash.log"
-	pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
-	stats = result_parsers.parse_read_stats(pathToMashLog, pathToTotalBP)
-	'''
-	
-	#parse genome mash results
-	pathToMashGenomeScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.genome.tsv"
-	mash_hits = result_parsers.parse_mash_result(pathToMashGenomeScreenTSV)
+    print("Parsing the QC results")
+    
+    #parse read stats
+    '''
+    pathToMashLog = outputDir + "/qcResult/" + ID + "/" + "mash.log"
+    pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
+    stats = result_parsers.parse_read_stats(pathToMashLog, pathToTotalBP)
+    '''
+    
+    #parse genome mash results
+    pathToMashGenomeScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.genome.tsv"
+    mash_hits = result_parsers.parse_mash_result(pathToMashGenomeScreenTSV)
 
-	# 'shared_hashes' field is string in format '935/1000'
-	# Threshold is 300 below highest numerator (ie. '935/100' -> 635)
-	mash_hits_score_threshold = int(mash_hits[0]['shared_hashes'].split("/")[0]) - 300
-	print("*** mash_hits_score_threshold: " + str(mash_hits_score_threshold))
-	def score_above_threshold(mash_result, score_threshold):
-		score = int(mash_result['shared_hashes'].split("/")[0])
-		if (score >= score_threshold and mash_result['query_comment'].find("phiX") == -1):
-			return True
-		else:
-			return False
-		
-	filtered_mash_hits = list(filter(
-		lambda x: score_above_threshold(x, mash_hits_score_threshold),
-		mash_hits))
-	
-	# parse plasmid mash
-	pathToMashPlasmidScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.plasmid.tsv"
-	mash_plasmid_hits = result_parsers.parse_mash_result(pathToMashPlasmidScreenTSV)
-	# 'shared_hashes' field is string in format '935/1000'
-	# Threshold is 100 below highest numerator (ie. '935/100' -> 835)
-	mash_plasmid_hits_score_threshold = int(mash_plasmid_hits[0]['shared_hashes'].split("/")[0]) - 100
-	filtered_mash_plasmid_hits = list(filter(
-		lambda x: score_above_threshold(x, mash_plasmid_hits_score_threshold),
-		mash_plasmid_hits))
-	
-	# parse fastqc
-	pathToFastQCR1 = outputDir + "/qcResult/" + ID + "/" + R1[R1.find(os.path.basename(R1)):R1.find(".")] + "_fastqc/summary.txt"
-	pathToFastQCR2 = outputDir + "/qcResult/" + ID + "/" + R2[R2.find(os.path.basename(R2)):R2.find(".")] + "_fastqc/summary.txt"
-	fastqcR1 = result_parsers.parse_fastqc_result(pathToFastQCR1)
-	fastqcR2 = result_parsers.parse_fastqc_result(pathToFastQCR2)
-	fastqc = {}
-	fastqc["R1"]=fastqcR1
-	fastqc["R2"]=fastqcR2
-	 
+    # 'shared_hashes' field is string in format '935/1000'
+    # Threshold is 300 below highest numerator (ie. '935/100' -> 635)
+    mash_hits_score_threshold = int(mash_hits[0]['shared_hashes'].split("/")[0]) - 300
+    print("*** mash_hits_score_threshold: " + str(mash_hits_score_threshold))
+    def score_above_threshold(mash_result, score_threshold):
+        score = int(mash_result['shared_hashes'].split("/")[0])
+        if (score >= score_threshold and mash_result['query_comment'].find("phiX") == -1):
+            return True
+        else:
+            return False
+        
+    filtered_mash_hits = list(filter(
+        lambda x: score_above_threshold(x, mash_hits_score_threshold),
+        mash_hits))
+    
+    # parse plasmid mash
+    pathToMashPlasmidScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.plasmid.tsv"
+    mash_plasmid_hits = result_parsers.parse_mash_result(pathToMashPlasmidScreenTSV)
+    # 'shared_hashes' field is string in format '935/1000'
+    # Threshold is 100 below highest numerator (ie. '935/100' -> 835)
+    mash_plasmid_hits_score_threshold = int(mash_plasmid_hits[0]['shared_hashes'].split("/")[0]) - 100
+    filtered_mash_plasmid_hits = list(filter(
+        lambda x: score_above_threshold(x, mash_plasmid_hits_score_threshold),
+        mash_plasmid_hits))
+    
+    # parse fastqc
+    pathToFastQCR1 = outputDir + "/qcResult/" + ID + "/" + R1[R1.find(os.path.basename(R1)):R1.find(".")] + "_fastqc/summary.txt"
+    pathToFastQCR2 = outputDir + "/qcResult/" + ID + "/" + R2[R2.find(os.path.basename(R2)):R2.find(".")] + "_fastqc/summary.txt"
+    fastqcR1 = result_parsers.parse_fastqc_result(pathToFastQCR1)
+    fastqcR2 = result_parsers.parse_fastqc_result(pathToFastQCR2)
+    fastqc = {}
+    fastqc["R1"]=fastqcR1
+    fastqc["R2"]=fastqcR2
+     
 
-	#all the qC result are parsed now, lets do some QC logic
-	qcVerdicts = {
-		"Multiple_Species_Contamination":False,
-		"Same_As_Expected_Species":False,
-		"FASTQ_Contains_Plasmids":False,
-		"Acceptable Coverage":False,
-		"Acceptable_FastQC_Forward":False,
-		"Acceptable_FastQC_Reverse":False,
-	}
+    #all the qC result are parsed now, lets do some QC logic
+    qcVerdicts = {
+        "Multiple_Species_Contamination":False,
+        "Same_As_Expected_Species":False,
+        "FASTQ_Contains_Plasmids":False,
+        "Acceptable Coverage":False,
+        "Acceptable_FastQC_Forward":False,
+        "Acceptable_FastQC_Reverse":False,
+    }
 
-	#look at mash results first
-	if (len(filtered_mash_hits) > 1):
-		qcVerdicts["Multiple_Species_Contamination"] = True 
-	
-	for mash_hit in filtered_mash_hits:
-		species = mash_hit['query_comment']
-		if (species.find(expectedSpecies) > -1):
-			qcVerdicts["Same_As_Expected_Species"] = True
-	
-	if (len(filtered_mash_plasmid_hits) > 0):
-		qcVerdicts["FASTQ_Contains_Plasmids"] = True
+    #look at mash results first
+    if (len(filtered_mash_hits) > 1):
+        qcVerdicts["Multiple_Species_Contamination"] = True 
+    
+    for mash_hit in filtered_mash_hits:
+        species = mash_hit['query_comment']
+        if (species.find(expectedSpecies) > -1):
+            qcVerdicts["Same_As_Expected_Species"] = True
+    
+    if (len(filtered_mash_plasmid_hits) > 0):
+        qcVerdicts["FASTQ_Contains_Plasmids"] = True
 
-	#look at fastqc results
-	if (fastqc["R1"]["basic_statistics"] == "PASS" and fastqc["R1"]["per_base_sequence_quality"] == "PASS" and fastqc["R1"]["sequence_length_distribution"] == "PASS" ):
-		qcVerdicts["Acceptable_FastQC_Forward"] = True 
-	if (fastqc["R2"]["basic_statistics"] == "PASS" and fastqc["R2"]["per_base_sequence_quality"] == "PASS" and fastqc["R2"]["sequence_length_distribution"] == "PASS" ):
-		qcVerdicts["Acceptable_FastQC_Reverse"] = True 
-	
-	#download a reference genome
-	print("Downloading reference genomes")
-	referenceGenomes = []
-	if (not qcVerdicts["Multiple_Species_Contamination"]):
-		for mash_hit in filtered_mash_hits: #for all the mash hits, aka reference genomes
-			qID = mash_hit['query_id'] #hit genome within mash results
-			species_name_start = int(mash_hit['query_comment'].index(".")) + 3 #find the start of species name within query_comment column
-			species_name_stop = int (mash_hit['query_comment'].index(",")) #find the end of the species name within query_comment column
-			if (mash_hit['query_comment'].find("phiX") > -1):
-				species = "PhiX" #phix
-			else:
-				species = str(mash_hit['query_comment'])[species_name_start: species_name_stop] #assign proper species name for reference genome file name
-				# find gcf accession
-				# TODO: document this or clean it up to be more readable
-				gcf = (qID[:qID.find("_",5)]).replace("_","") #find the full gcf accession for ncbi FTP
-				gcf = [gcf[i:i+3] for i in range(0, len(gcf), 3)] #break the gcf accession into k=3
+    #look at fastqc results
+    if (fastqc["R1"]["basic_statistics"] == "PASS" and fastqc["R1"]["per_base_sequence_quality"] == "PASS" and fastqc["R1"]["sequence_length_distribution"] == "PASS" ):
+        qcVerdicts["Acceptable_FastQC_Forward"] = True 
+    if (fastqc["R2"]["basic_statistics"] == "PASS" and fastqc["R2"]["per_base_sequence_quality"] == "PASS" and fastqc["R2"]["sequence_length_distribution"] == "PASS" ):
+        qcVerdicts["Acceptable_FastQC_Reverse"] = True 
+    
+    #download a reference genome
+    print("Downloading reference genomes")
+    referenceGenomes = []
+    if (not qcVerdicts["Multiple_Species_Contamination"]):
+        for mash_hit in filtered_mash_hits: #for all the mash hits, aka reference genomes
+            qID = mash_hit['query_id'] #hit genome within mash results
+            species_name_start = int(mash_hit['query_comment'].index(".")) + 3 #find the start of species name within query_comment column
+            species_name_stop = int (mash_hit['query_comment'].index(",")) #find the end of the species name within query_comment column
+            if (mash_hit['query_comment'].find("phiX") > -1):
+                species = "PhiX" #phix
+            else:
+                species = str(mash_hit['query_comment'])[species_name_start: species_name_stop] #assign proper species name for reference genome file name
+                # find gcf accession
+                # TODO: document this or clean it up to be more readable
+                gcf = (qID[:qID.find("_",5)]).replace("_","") #find the full gcf accession for ncbi FTP
+                gcf = [gcf[i:i+3] for i in range(0, len(gcf), 3)] #break the gcf accession into k=3
 
-				assembly = qID[:qID.find("_genomic.fna.gz")] #find the assembly name
+                assembly = qID[:qID.find("_genomic.fna.gz")] #find the assembly name
 
-				#build the urls
-				fastaURL = "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/" + gcf[0] + "/" + gcf[1] + "/" + gcf[2] + "/" + gcf[3] + "/" + assembly + "/" + qID #url to fasta
-				assemblyStatURL = "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/" + gcf[0] + "/" + gcf[1] + "/" + gcf[2] + "/" + gcf[3] + "/" + assembly + "/" + assembly + "_assembly_stats.txt" #url to assembly stat
-				referencePath = os.path.abspath(outputDir + "/qcResult/" + ID + "/" + species.replace(" ",""))
-				referenceGenomes.append(referencePath)
+                #build the urls
+                fastaURL = "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/" + gcf[0] + "/" + gcf[1] + "/" + gcf[2] + "/" + gcf[3] + "/" + assembly + "/" + qID #url to fasta
+                assemblyStatURL = "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/" + gcf[0] + "/" + gcf[1] + "/" + gcf[2] + "/" + gcf[3] + "/" + assembly + "/" + assembly + "_assembly_stats.txt" #url to assembly stat
+                referencePath = os.path.abspath(outputDir + "/qcResult/" + ID + "/" + species.replace(" ",""))
+                referenceGenomes.append(referencePath)
 
-				httpGetFile(fastaURL, referencePath + ".gz") #fetch the fasta gz
-				httpGetFile(assemblyStatURL, referencePath + "_genomeStats.txt") # fetch the genome stat
-				with gzip.open(referencePath + ".gz", 'rb') as f:
-					gzContent = f.read()
-				with open(referencePath, 'wb') as out:
-					out.write(gzContent)
-				os.remove(referencePath + ".gz")
-	else: #throw an error if it contains contaminations
-		print("Contaminated Genome assembly...resequencing required")
-		raise Exception("contamination and mislabeling...crashing")
-		
-	#check to make sure we ONLY have ONE reference.
-	if (len(referenceGenomes) > 1 ):
-		raise Exception ("there are multiple reference genomes")
-	elif (len(referenceGenomes) == 0):
-		raise Exception ("no reference genoe identified")
-		
-	
-	#now we estimate our coverage using total reads and expected genome size
-	
-	#find expected genome size
-	pathToReferenceStats = referenceGenomes[0] + "_genomeStats.txt"
-	with open( pathToReferenceStats, 'r') as referenceStats:
-		genomeStats = referenceStats.read().splitlines()
-	for line in genomeStats:
-		if (line.find("all	all	all	all	total-length") > -1): #find the total length stat
-			expectedGenomeSize = float(line.split("\t")[5].strip()) 
+                httpGetFile(fastaURL, referencePath + ".gz") #fetch the fasta gz
+                httpGetFile(assemblyStatURL, referencePath + "_genomeStats.txt") # fetch the genome stat
+                with gzip.open(referencePath + ".gz", 'rb') as f:
+                    gzContent = f.read()
+                with open(referencePath, 'wb') as out:
+                    out.write(gzContent)
+                os.remove(referencePath + ".gz")
+    else: #throw an error if it contains contaminations
+        print("Contaminated Genome assembly...resequencing required")
+        raise Exception("contamination and mislabeling...crashing")
+        
+    #check to make sure we ONLY have ONE reference.
+    if (len(referenceGenomes) > 1 ):
+        raise Exception ("there are multiple reference genomes")
+    elif (len(referenceGenomes) == 0):
+        raise Exception ("no reference genoe identified")
+        
+    
+    #now we estimate our coverage using total reads and expected genome size
+    
+    #find expected genome size
+    pathToReferenceStats = referenceGenomes[0] + "_genomeStats.txt"
+    with open( pathToReferenceStats, 'r') as referenceStats:
+        genomeStats = referenceStats.read().splitlines()
+    for line in genomeStats:
+        if (line.find("all	all	all	all	total-length") > -1): #find the total length stat
+            expectedGenomeSize = float(line.split("\t")[5].strip()) 
 
-	#find total base count
-	pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
-	with open(pathToTotalBP, 'r') as totalbp_file:
-		total_bp = float(totalbp_file.readline())
-	
-	#calculate coverage
-	coverage = total_bp / expectedGenomeSize
-			
-	if (coverage >= 30):
-		qcVerdicts["Acceptable Coverage"] = True
-	
-	print(str(total_bp))
-	print(str(expectedGenomeSize))
-	print(str(coverage))
-	print(str(qcVerdicts["Multiple_Species_Contamination"]))
-	print(str(qcVerdicts["Same_As_Expected_Species"]))
-	print(str(qcVerdicts["FASTQ_Contains_Plasmids"]))
-	print(str(qcVerdicts["Acceptable Coverage"]))
-	print(str(qcVerdicts["Acceptable_FastQC_Forward"]))
-	print(str(qcVerdicts["Acceptable_FastQC_Reverse"]))
+    #find total base count
+    pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
+    with open(pathToTotalBP, 'r') as totalbp_file:
+        total_bp = float(totalbp_file.readline())
+    
+    #calculate coverage
+    coverage = total_bp / expectedGenomeSize
+            
+    if (coverage >= 30):
+        qcVerdicts["Acceptable Coverage"] = True
+    
+    print(str(total_bp))
+    print(str(expectedGenomeSize))
+    print(str(coverage))
+    print(str(qcVerdicts["Multiple_Species_Contamination"]))
+    print(str(qcVerdicts["Same_As_Expected_Species"]))
+    print(str(qcVerdicts["FASTQ_Contains_Plasmids"]))
+    print(str(qcVerdicts["Acceptable Coverage"]))
+    print(str(qcVerdicts["Acceptable_FastQC_Forward"]))
+    print(str(qcVerdicts["Acceptable_FastQC_Reverse"]))
 
-	
-	print("Formatting the QC results")
+    
+    print("Formatting the QC results")
 
-	output.append("\n\n~~~~~~~QC summary~~~~~~~")
-	output.append("Expected genome size: " + str(expectedGenomeSize))
-	output.append("Estimated coverage: " + str(coverage))
-	output.append("Expected isolate species: " + expectedSpecies)
+    output.append("\n\n~~~~~~~QC summary~~~~~~~")
+    output.append("Expected genome size: " + str(expectedGenomeSize))
+    output.append("Estimated coverage: " + str(coverage))
+    output.append("Expected isolate species: " + expectedSpecies)
 
-	output.append("\nFastQC summary:")
-	output.append("\nforward read qc:")
-	for key, value in fastqcR1.items():
-		output.append(key + ": " + value)
-		if (value == "WARN" or value == "FAIL"):
-			notes.append("FastQC: Forward read, " + key + " " + value)
+    output.append("\nFastQC summary:")
+    output.append("\nforward read qc:")
+    for key, value in fastqcR1.items():
+        output.append(key + ": " + value)
+        if (value == "WARN" or value == "FAIL"):
+            notes.append("FastQC: Forward read, " + key + " " + value)
 
-	output.append("\nreverse read qc:")
-	for key, value in fastqcR2.items():
-		output.append(key + ": " + value)
-		if (value == "WARN" or value == "FAIL"):
-			notes.append("FastQC: Reverse read, " + key + " " + value)
+    output.append("\nreverse read qc:")
+    for key, value in fastqcR2.items():
+        output.append(key + ": " + value)
+        if (value == "WARN" or value == "FAIL"):
+            notes.append("FastQC: Reverse read, " + key + " " + value)
 
-	output.append("\nmash predicted genomes")
-	for mash_hit in filtered_mash_hits:
-		output.append(mash_hit['query_comment'])
+    output.append("\nmash predicted genomes")
+    for mash_hit in filtered_mash_hits:
+        output.append(mash_hit['query_comment'])
 
-	output.append("\nmash predicted plasmids")
-	for mash_plasmid_hit in mash_plasmid_hits:
-		output.append(mash_plasmid_hit['query_comment'])
-	
+    output.append("\nmash predicted plasmids")
+    for mash_plasmid_hit in mash_plasmid_hits:
+        output.append(mash_plasmid_hit['query_comment'])
+    
 
-	output.append("\nDetailed mash genome hits: ")
-	for mash_hit in mash_hits:
-		output.append(
-			str(mash_hit['identity']) + '\t' +
-			mash_hit['shared_hashes'] + '\t' +
-			str(mash_hit['median_multiplicity']) + '\t' +
-			str(mash_hit['p_value']) + '\t' +
-			mash_hit['query_id'] + '\t' +
-			mash_hit['query_comment']
-		)
-	
-	output.append("\nDetailed mash plasmid hits: ")
-	for mash_plasmid_hit in mash_plasmid_hits:
-		output.append(
-			str(mash_plasmid_hit['identity']) + '\t' +
-			mash_plasmid_hit['shared_hashes'] + '\t' +
-			str(mash_plasmid_hit['median_multiplicity']) + '\t' +
-			str(mash_plasmid_hit['p_value']) + '\t' +
-			mash_plasmid_hit['query_id'] + '\t' +
-			mash_plasmid_hit['query_comment']
-		)
+    output.append("\nDetailed mash genome hits: ")
+    for mash_hit in mash_hits:
+        output.append(
+            str(mash_hit['identity']) + '\t' +
+            mash_hit['shared_hashes'] + '\t' +
+            str(mash_hit['median_multiplicity']) + '\t' +
+            str(mash_hit['p_value']) + '\t' +
+            mash_hit['query_id'] + '\t' +
+            mash_hit['query_comment']
+        )
+    
+    output.append("\nDetailed mash plasmid hits: ")
+    for mash_plasmid_hit in mash_plasmid_hits:
+        output.append(
+            str(mash_plasmid_hit['identity']) + '\t' +
+            mash_plasmid_hit['shared_hashes'] + '\t' +
+            str(mash_plasmid_hit['median_multiplicity']) + '\t' +
+            str(mash_plasmid_hit['p_value']) + '\t' +
+            mash_plasmid_hit['query_id'] + '\t' +
+            mash_plasmid_hit['query_comment']
+        )
 
-	#qcsummary
-	output.append("\n\nQC Information:")
-	
-	print("step 2: genome assembly and QC")
+    #qcsummary
+    output.append("\n\nQC Information:")
+    
+    print("step 2: genome assembly and QC")
 
-	#run the assembly shell script.
-	#input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=tmpdir for shovill, 6=reference genome, 7=buscoDB
-	cmd = [scriptDir + "/pipeline_assembly.sh", ID, R1, R2, outputDir, tempDir, referenceGenomes[0], buscodb]
-	result = execute(cmd, curDir)
-	
-	print("Parsing assembly results")
-	#get the correct busco and quast result file to parse
+    #run the assembly shell script.
+    #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=tmpdir for shovill, 6=reference genome, 7=buscoDB
+    cmd = [scriptDir + "/pipeline_assembly.sh", ID, R1, R2, outputDir, tempDir, referenceGenomes[0], buscodb]
+    result = execute(cmd, curDir)
+    
+    print("Parsing assembly results")
+    #get the correct busco and quast result file to parse
 
-	buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".busco" + "/short_summary_" + ID + ".busco.txt")
-	quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
-	#populate the busco and quast result object
-	buscoResults = result_parsers.parse_busco_result(buscoPath)
-	quastResults = result_parsers.parse_busco_result(quastPath)
+    buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".busco" + "/short_summary_" + ID + ".busco.txt")
+    quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
+    #populate the busco and quast result object
+    buscoResults = result_parsers.parse_busco_result(buscoPath)
+    quastResults = result_parsers.parse_busco_result(quastPath)
 
 if __name__ == "__main__":
-	start = time.time()
-	print("Starting workflow...")
-	main()
-	end = time.time()
-	print("Finished!\nThe analysis used: " + str(end - start) + " seconds")
+    start = time.time()
+    print("Starting workflow...")
+    main()
+    end = time.time()
+    print("Finished!\nThe analysis used: " + str(end - start) + " seconds")

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -124,11 +124,14 @@ def main():
     result = execute(cmd, curDir)
 
     print("Parsing the QC results")
+	
     #parse read stats
-    pathToMashLog = outputDir + "/qcResult/" + ID + "/" + "mash.log"
+    '''
+	pathToMashLog = outputDir + "/qcResult/" + ID + "/" + "mash.log"
     pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
     stats = result_parsers.parse_read_stats(pathToMashLog, pathToTotalBP)
-
+	'''
+	
     #parse genome mash results
     pathToMashGenomeScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.genome.tsv"
     mash_hits = result_parsers.parse_mash_result(pathToMashGenomeScreenTSV)
@@ -167,14 +170,122 @@ def main():
     fastqc["R1"]=fastqcR1
     fastqc["R2"]=fastqcR2
      
-    # parse kraken2 result
-    pathToKrakenResult = outputDir + "/qcResult/" + ID + "/kraken2.genome.report"
-    kraken_genomes = result_parsers.parse_kraken_result(pathToKrakenResult)
+    #parse kraken2 result
+	#pathToKrakenResult = outputDir + "/qcResult/" + ID + "/kraken2.genome.report"
+    #kraken_genomes = result_parsers.parse_kraken_result(pathToKrakenResult)
 
-    print("Formatting the QC results")
-    multiple = False
+	
+
+	multipleSpecies = False
     correctSpecies = False
-    correctReference = ""
+	containsPlasmid = False
+	acceptableCoverage = False
+	acceptableFastQCForward = False
+	acceptableFastQCReverse = False
+
+	#all the qC result are parsed now, lets do some QC logic
+	#look at mash results first
+	if (len(filtered_mash_hits) > 1):
+        multipleSpecies = True
+	
+	for mash_hit in filtered_mash_hits:
+        species = mash_hit['query_comment']
+        if (species.find(expectedSpecies) > -1):
+            correctSpecies=True
+	
+	if (len(filtered_mash_plasmid_hits) > 0):
+		containsPlasmid = True
+    #look at kraken results > Removed, simplified to using only mash. Validation with Kraken2 is no longer required as we are no longer doing contamination filtering.
+	# TODO: filter kraken_genomes based on contamination thresholds
+    # if (len(kraken_genomes) > 1):
+    #     output.append("!!!Kraken2 predicted multiple species, possible contamination?")
+    #     notes.append("Kraken2: multiple species, possible contamination.")
+    #     #multipleSpecies = True
+    # elif (len(kraken_genomes) == 1):
+    #     multipleSpecies = False
+        
+    #for kraken_genome in  kraken_genomes:
+    #    if (kraken_genome['taxon_name'] == expectedSpecies):
+    #        correctSpecies = True
+
+	#look at fastqc results
+  
+	if (fastqc["R1"]["basic_statistics"] == "PASS" and fastqc["R1"]["per_base_sequence_quality"] == "PASS" and fastqc["R1"]["sequence_length_distribution"] == "PASS" ):
+		acceptableFastQCForward = True
+	if (fastqc["R2"]["basic_statistics"] == "PASS" and fastqc["R2"]["per_base_sequence_quality"] == "PASS" and fastqc["R2"]["sequence_length_distribution"] == "PASS" ):
+		acceptableFastQCReverse = True
+	
+	#download a reference genome
+	print("Downloading reference genomes")
+	referenceGenomes = []
+	if (not multipleSpecies):
+		for mash_hit in filtered_mash_hits: #for all the mash hits, aka reference genomes
+			qID = mash_hit['query_id'] #hit genome within mash results
+			species_name_start = int(mash_hit['query_comment'].index(".")) + 3 #find the start of species name within query_comment column
+			species_name_stop = int (mash_hit['query_comment'].index(",")) #find the end of the species name within query_comment column
+			if (mash_hit['query_comment'].find("phiX") > -1):
+				species = "PhiX" #phix
+			else:
+				species = str(mash_hit['query_comment'])[species_name_start: species_name_stop] #assign proper species name for reference genome file name
+				# find gcf accession
+				# TODO: document this or clean it up to be more readable
+				gcf = (qID[:qID.find("_",5)]).replace("_","") #find the full gcf accession for ncbi FTP
+				gcf = [gcf[i:i+3] for i in range(0, len(gcf), 3)] #break the gcf accession into k=3
+
+				assembly = qID[:qID.find("_genomic.fna.gz")] #find the assembly name
+
+				#build the urls
+				fastaURL = "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/" + gcf[0] + "/" + gcf[1] + "/" + gcf[2] + "/" + gcf[3] + "/" + assembly + "/" + qID #url to fasta
+				assemblyStatURL = "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/" + gcf[0] + "/" + gcf[1] + "/" + gcf[2] + "/" + gcf[3] + "/" + assembly + "/" + qID + "_assembly_stats.txt" #url to assembly stat
+				referencePath = os.path.abspath(outputDir + "/qcResult/" + ID + "/" + species.replace(" ",""))
+				referenceGenomes.append(referencePath)
+
+				httpGetFile(url, referencePath + ".gz") #fetch the fasta gz
+				httpGetFile(url, referencePath + "_genomeStats.txt") # fetch the genome stat
+				with gzip.open(referencePath + ".gz", 'rb') as f:
+					gzContent = f.read()
+				with open(referencePath, 'wb') as out:
+					out.write(gzContent)
+				os.remove(referencePath + ".gz")
+	else: #throw an error if it contains contaminations
+		print("Contaminated Genome assembly...resequencing required")
+        raise Exception("contamination and mislabeling...crashing")
+		
+	#check to make sure we ONLY have ONE reference.
+	if (len(referenceGenomes) > 1 ):
+		raise Exception ("there are multiple reference genomes")
+	elif (len(referenceGenomes) == 0)
+		raise Exception ("no reference genoe identified")
+		
+	
+	#now we estimate our coverage using total reads and expected genome size
+	
+	#find expected genome size
+	pathToReferenceStats = referenceGenomes[0] + "_genomeStats.txt"
+	with open( pathToReferenceStats, 'r') as referenceStats:
+		if (referenceStats.readline().find("all	all	all	all	total-length") > -1): #find the total length stat
+			expectedGenomeSize = float(s.split("\t")[5].strip()) 
+
+	#find total base count
+    pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
+	with open(pathToTotalBP, 'r') as totalbp_file:
+        total_bp = float(totalbp_file.readline())
+	
+	#calculate coverage
+	coverage = total_bp / expectedGenomeSize
+			
+	if (coverage >= 30):
+		acceptableCoverage = True
+	
+	print(str(multiple))
+	print(str(correctSpecies))
+	print(str(containsPlasmid))
+	print(str(acceptableCoverage))
+	print(str(acceptableFastQCForward))
+	print(str(acceptableFastQCReverse))
+
+	
+    print("Formatting the QC results")
 
     output.append("\n\n~~~~~~~QC summary~~~~~~~")
     output.append("Estimated genome size: " + str(stats['estimated_genome_size']))
@@ -243,41 +354,33 @@ def main():
     #qcsummary
     output.append("\n\nQC Information:")
 
-    present = False
-    # TODO: filter kraken_genomes based on contamination thresholds
-    # if (len(kraken_genomes) > 1):
-    #     output.append("!!!Kraken2 predicted multiple species, possible contamination?")
-    #     notes.append("Kraken2: multiple species, possible contamination.")
-    #     #multiple = True
-    # elif (len(kraken_genomes) == 1):
-    #     multiple = False
-        
-    for kraken_genome in  kraken_genomes:
-        if (kraken_genome['taxon_name'] == expectedSpecies):
-            present = True
 
+	'''
     if present:
         output.append("The expected species is predicted by kraken 2")
         #correctSpecies = True
     else:
         output.append("!!!The expected species is NOT predicted by kraken2, contamination? mislabeling?")
         notes.append("Kraken2: Not expected species. Possible contamination or mislabeling")
-
+	
     if (stats['estimated_depth_of_coverage'] < 30):
         output.append("!!!Coverage is lower than 30. Estimated depth: " + str(stats['estimated_depth_of_coverage']))
-
+	
+	
     if (len(filtered_mash_hits) > 1):
         output.append("!!!MASH predicted multiple species, possible contamination?")
-        multiple = True
+        multipleSpecies = True
     elif (len(filtered_mash_hits) < 1):
         output.append("!!!MASH had no hits, this is an unknown species")
         notes.append("Mash: Unknown Species")
-                
+    '''
+	'''
     present=False
     for mash_hit in filtered_mash_hits:
         species = mash_hit['query_comment']
         if (species.find(expectedSpecies) > -1):
             present=True
+	
     if present:
         output.append("The expected species is predicted by mash")
         correctSpecies = True
@@ -291,60 +394,37 @@ def main():
         notes.append("Mash: no plasmid predicted")
 
     #hack: throw exception if this analysis should not proceed due to contamination and mislabelling
-    if (multiple and not correctSpecies):
-        out = open(outputDir + "/summary/" + ID +".err", 'a')
-        out.write('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
-        #raise Exception('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
-    print("Downloading reference genomes")
-
-    referenceGenomes = []
-    for mash_hit in filtered_mash_hits:
-        qID = mash_hit['query_id']
-        species_name_start = int(mash_hit['query_comment'].index(".")) + 3
-        species_name_stop = int (mash_hit['query_comment'].index(","))
-        if (mash_hit['query_comment'].find("phiX") > -1):
-            species = "PhiX"
-        else:
-            species = str(mash_hit['query_comment'])[species_name_start: species_name_stop]
-        # find gcf accession
-        # TODO: document this or clean it up to be more readable
-        gcf = (qID[:qID.find("_",5)]).replace("_","")
-        gcf = [gcf[i:i+3] for i in range(0, len(gcf), 3)]
-        print("*** GCF: " + str(gcf))
-        assembly = qID[:qID.find("_genomic.fna.gz")]
-        url = "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/" + gcf[0] + "/" + gcf[1] + "/" + gcf[2] + "/" + gcf[3] + "/" + assembly + "/" + qID
-        referencePath = os.path.abspath(outputDir + "/qcResult/" + ID + "/" + species.replace(" ",""))
-        referenceGenomes.append(referencePath)
-
-        httpGetFile(url, referencePath + ".gz")
-        with gzip.open(referencePath + ".gz", 'rb') as f:
-            gzContent = f.read()
-        with open(referencePath, 'wb') as out:
-            out.write(gzContent)
-        os.remove(referencePath + ".gz")
-
-    print("step 2: genome assembly and QC")
-    correctAssembly = ""
-
+    #if (multipleSpecies and not correctSpecies):
+    #    out = open(outputDir + "/summary/" + ID +".err", 'a')
+    #    out.write('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
+    #    #raise Exception('GO RESEQUENCE THIS SAMPLE: It has contamination issues AND mislabelled')
+    
+	#identify and download reference genomes, this should only return one reference.
+	'''
+	
+	'''
+    correctReference = ""
     if (len(referenceGenomes) > 1):
         for item in referenceGenomes:
             if (item.find(expectedSpecies.replace(" ", "")) > -1): #found the right genome
-                correctAssembly = os.path.basename(item)
+                correctReference = os.path.basename(item)
     else:
-        correctAssembly = os.path.basename(referenceGenomes[0])
-    if (correctAssembly == ""):
+        correctReference = os.path.basename(referenceGenomes[0])
+		
+    if (correctReference == ""):
         raise Exception("no reference genome...crashing")
-    
-    if (multiple):
-        print("Contaminated Genome assembly...No Correct Species Either")
-        raise Exception("contamination and mislabeling...crashing")
-    else:
-        #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=tmpdir for shovill, 6=reference genome, 7=buscoDB
-        cmd = [scriptDir + "/pipeline_assembly.sh", ID, R1, R2, outputDir, tempDir, referenceGenomes[0], buscodb, correctAssembly]
-        result = execute(cmd, curDir)
+    '''
+	print("step 2: genome assembly and QC")
+
+	#run the assembly shell script.
+	#input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=tmpdir for shovill, 6=reference genome, 7=buscoDB
+	cmd = [scriptDir + "/pipeline_assembly.sh", ID, R1, R2, outputDir, tempDir, referenceGenomes[0], buscodb]
+	result = execute(cmd, curDir)
     
     print("Parsing assembly results")
     #get the correct busco and quast result file to parse
+	
+	'''
     correctAssembly = ""
     buscoPath = "" 
     quastPath = ""
@@ -363,7 +443,9 @@ def main():
 
     if (buscoPath == "" or quastPath == ""):
         raise Exception('theres no reference genome for this sample for whatever reason...')
-
+	'''
+	buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".busco" + "/short_summary_" + ID + ".busco.txt")
+	quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
     #populate the busco and quast result object
     buscoResults = result_parsers.parse_busco_result(buscoPath)
     quastResults = result_parsers.parse_busco_result(quastPath)

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -231,7 +231,7 @@ def main():
     if (len(reference_genomes) > 1 ):
         raise Exception ("there are multiple reference genomes")
     elif (len(reference_genomes) == 0):
-        raise Exception ("no reference genoe identified")
+        raise Exception ("no reference genome identified")
         
     
     #now we estimate our coverage using total reads and expected genome size

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -124,14 +124,6 @@ def main():
     result = execute(cmd, curDir)
 
     print("Parsing the QC results")
-    
-    #parse read stats
-    '''
-    pathToMashLog = outputDir + "/qcResult/" + ID + "/" + "mash.log"
-    pathToTotalBP = outputDir + "/qcResult/" + ID + "/" + "totalbp"
-    stats = result_parsers.parse_read_stats(pathToMashLog, pathToTotalBP)
-    '''
-    
     #parse genome mash results
     pathToMashGenomeScreenTSV = outputDir + "/qcResult/" + ID + "/" + "mashscreen.genome.tsv"
     mash_hits = result_parsers.parse_mash_result(pathToMashGenomeScreenTSV)
@@ -263,16 +255,16 @@ def main():
     if (coverage >= 30):
         qcVerdicts["Acceptable Coverage"] = True
     
-    print(str(total_bp))
-    print(str(expectedGenomeSize))
-    print(str(coverage))
-    print(str(qcVerdicts["Multiple_Species_Contamination"]))
-    print(str(qcVerdicts["Same_As_Expected_Species"]))
-    print(str(qcVerdicts["FASTQ_Contains_Plasmids"]))
-    print(str(qcVerdicts["Acceptable Coverage"]))
-    print(str(qcVerdicts["Acceptable_FastQC_Forward"]))
-    print(str(qcVerdicts["Acceptable_FastQC_Reverse"]))
-
+    print("total bases: " + str(total_bp))
+    print("expected genome size: " + str(expectedGenomeSize))
+    print("coverage: " + str(coverage))
+	print("")
+    print("contamination: " + str(qcVerdicts["Multiple_Species_Contamination"]))
+    print("same as the expected species: " + str(qcVerdicts["Same_As_Expected_Species"]))
+    print("contains plasmids: " + str(qcVerdicts["FASTQ_Contains_Plasmids"]))
+    print("acceptable coverage: " + str(qcVerdicts["Acceptable Coverage"]))
+    print("acceptable forward reads quality: " + str(qcVerdicts["Acceptable_FastQC_Forward"]))
+    print("acceptable reverse reads quality: " + str(qcVerdicts["Acceptable_FastQC_Reverse"]))
     
     print("Formatting the QC results")
 

--- a/assembly/pipeline_qc.sh
+++ b/assembly/pipeline_qc.sh
@@ -9,10 +9,10 @@
 #$ -o ./logs/$JOB_ID.log
 
 ################################################################################
-# J-J-J-Jia @ pipeline_qc.sh: runs seqtk, mash, kraken2 and fastqc for pre-assembly quality checks
+# J-J-J-Jia @ pipeline_qc.sh: runs seqtk, mash, and fastqc for pre-assembly quality checks
 #
 # input parameters: 1=id, 2=forward, 3=reverse, 4=output, 5=mashgenomerefdb, 6=mashplasmidrefdb, 7=kraken2db, 8=kraken2plasmiddb
-# Requires: mash, kraken2, fastqc, seqtk (all conda-ble)
+# Requires: mash, fastqc, seqtk (all conda-ble)
 #
 # pipeline_qc.sh BC16-Cfr035 BC16-Cfr035_S10_L001_R1_001.fastq.gz BC16-Cfr035_S10_L001_R2_001.fastq.gz output refseq.genomes.k21s1000.msh refseq.plasmid.k21s1000.msh 2018-09-20_standard 2018-09-20_plasmid
 ################################################################################
@@ -59,9 +59,6 @@ cat "$R1" > "$qcOutDir"/R1.fastq
 
 source activate mash-2.0
 
-#get estimation of genome size (k-mer method)
-#mash sketch -m 3 "$qcOutDir"/R1.fastq -o "$qcOutDir"/R1.fastq -p "$threads" -k 32 2> "$qcOutDir"/mash.log
-
 #identify species using genome database
 echo "comparing to reference genome db"
 mash screen -p "$threads" -w "$refDB" "$qcOutDir"/concatRawReads.fastq | sort -gr > "$qcOutDir"/mashscreen.genome.tsv
@@ -83,15 +80,6 @@ rm -rf "$qcOutDir"/*.html
 rm -rf "$qcOutDir"/*.zip
 
 source deactivate
-
-#kraken2 species classification
-#echo "kraken2 classfiication of reads"
-
-#source activate kraken2-2.0.7_beta
-
-#kraken2 --db "$k2db" --paired --threads "$threads" --report "$qcOutDir"/kraken2.genome.report --output "$qcOutDir"/kraken2.genome.classification "$R1" "$R2"
-
-#source deactivate
 
 #calculate the total number of basepairs in the read
 echo "calculating total bases of forward and reverse"

--- a/assembly/pipeline_qc.sh
+++ b/assembly/pipeline_qc.sh
@@ -60,7 +60,7 @@ cat "$R1" > "$qcOutDir"/R1.fastq
 source activate mash-2.0
 
 #get estimation of genome size (k-mer method)
-mash sketch -m 3 "$qcOutDir"/R1.fastq -o "$qcOutDir"/R1.fastq -p "$threads" -k 32 2> "$qcOutDir"/mash.log
+#mash sketch -m 3 "$qcOutDir"/R1.fastq -o "$qcOutDir"/R1.fastq -p "$threads" -k 32 2> "$qcOutDir"/mash.log
 
 #identify species using genome database
 echo "comparing to reference genome db"
@@ -85,16 +85,16 @@ rm -rf "$qcOutDir"/*.zip
 source deactivate
 
 #kraken2 species classification
-echo "kraken2 classfiication of reads"
+#echo "kraken2 classfiication of reads"
 
-source activate kraken2-2.0.7_beta
+#source activate kraken2-2.0.7_beta
 
-kraken2 --db "$k2db" --paired --threads "$threads" --report "$qcOutDir"/kraken2.genome.report --output "$qcOutDir"/kraken2.genome.classification "$R1" "$R2"
+#kraken2 --db "$k2db" --paired --threads "$threads" --report "$qcOutDir"/kraken2.genome.report --output "$qcOutDir"/kraken2.genome.classification "$R1" "$R2"
 
-source deactivate
+#source deactivate
 
 #calculate the total number of basepairs in the read
-echo "calculating read stats"
+echo "calculating total bases of forward and reverse"
 
 source activate seqtk-1.3
 


### PR DESCRIPTION
Refactoring of the preassembly QC code:
- Genome coverage now calculated using expected genome size of the reference genome and total bases from 'seqtk'
- Removed contamination filtering and assembly of contaminated sequencings. Currently workflow will raise an exception if input is deemed to be contaminated by MASH.
- Kraken2 species classification removed. Validation of contamination no longer required since contamination filtering is removed
- Reorganized the QC logic. PASS/FAIL of each QC tool now stored in a dictionary ("qcVerdicts")
- Fixed MASH always identifying multiple species. PHiX should not appear in the filtered list of MASH hits. 

