### PR TITLE
Post assembly qc

### DIFF
--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -273,7 +273,7 @@ def main():
     #run the assembly shell script.
     #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=tmpdir for shovill, 6=reference genome, 7=buscoDB
     cmd = [scriptDir + "/pipeline_assembly.sh", ID, R1, R2, outputDir, tempDir, reference_genomes[0], buscodb]
-    result = execute(cmd, curDir)
+    #result = execute(cmd, curDir)
     
     print("Parsing assembly results")
     #get the correct busco and quast result file to parse
@@ -298,6 +298,9 @@ def main():
     2. percent gc versus reference percent gc +- 5%
     3. genome fraction percent > 90
     '''
+    for keys in quastResults:
+        print(keys)
+    
     if (float(quastResults["total_length"]) <= float(quastResults["reference_length"]) * (1 + float(qc_cutoffs["quast_assembly_length_cutoff"])) and float(quastResults["total_length"]) >= float(quastResults["reference_length"]) * (1 - float(qc_cutoffs["quast_assembly_length_cutoff"]))): #check for condition 1
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
     if (float(quastResults["percent_GC"]) <= float(quastResults["reference_percent_GC"]) * (1+ float(qc_cutoffs["quast_percent_gc_cutoff"])) and float(quastResults["percent_GC"]) >= float(quastResults["reference_percent_GC"]) * (1 - float(qc_cutoffs["quast_percent_gc_cutoff"]))): #check for condition 2

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -300,7 +300,7 @@ def main():
     '''
     if (float(quastResults["total_length"]) <= float(quastResults["reference_length"]) * (1 + float(qc_cutoffs["quast_assembly_length_cutoff"])) and float(quastResults["total_length"]) >= float(quastResults["reference_length"]) * (1 - float(qc_cutoffs["quast_assembly_length_cutoff"]))): #check for condition 1
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
-    if (float(quastResults["percent_GC"]) <= float(quastResults["reference_percent_GC"]) * (1+ float(qc_cutoffs["quast_percent_gc_cutoff"]))) and float(quastResults["percent_GC"]) >= float(quastResults["reference_percent_GC"]) * (1 - float(qc_cutoffs["quast_percent_gc_cutoff"]))): #check for condition 2
+    if (float(quastResults["percent_GC"]) <= float(quastResults["reference_percent_GC"]) * (1+ float(qc_cutoffs["quast_percent_gc_cutoff"])) and float(quastResults["percent_GC"]) >= float(quastResults["reference_percent_GC"]) * (1 - float(qc_cutoffs["quast_percent_gc_cutoff"]))): #check for condition 2
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
     if (float(quastResults["genome_fraction_percent"]) >= int(qc_cutoffs["genome_fraction_percent_cutoff"])):
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -144,7 +144,7 @@ def main():
     print("running pipeline_qc.sh")
     #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=mashgenomerefdb, $6=mashplasmidrefdb, $7=kraken2db, $8=kraken2plasmiddb
     cmd = [scriptDir + "/pipeline_qc.sh", ID, R1, R2, outputDir, mashdb, mashplasmiddb, kraken2db, kraken2plasmiddb]
-    result = execute(cmd, curDir)
+    #result = execute(cmd, curDir)
 
     print("Parsing the QC results")
     #parse genome mash results

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -144,7 +144,7 @@ def main():
     print("running pipeline_qc.sh")
     #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=mashgenomerefdb, $6=mashplasmidrefdb, $7=kraken2db, $8=kraken2plasmiddb
     cmd = [scriptDir + "/pipeline_qc.sh", ID, R1, R2, outputDir, mashdb, mashplasmiddb, kraken2db, kraken2plasmiddb]
-    #result = execute(cmd, curDir)
+    result = execute(cmd, curDir)
 
     print("Parsing the QC results")
     #parse genome mash results
@@ -273,7 +273,7 @@ def main():
     #run the assembly shell script.
     #input parameters: 1 = id, 2= forward, 3 = reverse, 4 = output, 5=tmpdir for shovill, 6=reference genome, 7=buscoDB
     cmd = [scriptDir + "/pipeline_assembly.sh", ID, R1, R2, outputDir, tempDir, reference_genomes[0], buscodb]
-    #result = execute(cmd, curDir)
+    result = execute(cmd, curDir)
     
     print("Parsing assembly results")
     #get the correct busco and quast result file to parse

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -126,14 +126,14 @@ def main():
     }
     
     qc_cutoffs = {
-        "mash_hits_genome_score_cutoff" = 300 #genome mash will include all hits with scores (top hit score - $thisvalue)
-        "mash_hits_plasmid_score_cutoff" = 100 #plasmid mash will include all hits with scores (top hit score - $thisvalue)
-        "coverage_cutoff" = 30 #sequencing coverage greater than ($thisvalue) will pass the QC
-        "quast_assembly_length_cutoff" = 0.10 #QUAST QC: assembly length within +-($thisvalue) percent in reference to reference length will pass the QC 
-        "quast_percent_gc_cutoff" = 0.05 #QUAST QC: percent GC within +-($thisvalue) percent in reference to reference percent GC will pass the QC 
-        "genome_fraction_percent_cutoff" = 0.90 #QUAST QC: genome_fraction_percent less than ($thisvalue) will pass the QC
-        "busco_complete_single_cutoff" = 0.90 #BUSCO QC: complete single genes greater than ($thisvalue) percent will pass the QC
-        "busco_complete_duplicate_cutoff" = 0.10 #BUSCO QC: complete duplicate genes less than ($thisvalue) percent will pass the QC
+        "mash_hits_genome_score_cutoff":300 #genome mash will include all hits with scores (top hit score - $thisvalue)
+        "mash_hits_plasmid_score_cutoff":100 #plasmid mash will include all hits with scores (top hit score - $thisvalue)
+        "coverage_cutoff":30 #sequencing coverage greater than ($thisvalue) will pass the QC
+        "quast_assembly_length_cutoff":0.10 #QUAST QC: assembly length within +-($thisvalue) percent in reference to reference length will pass the QC 
+        "quast_percent_gc_cutoff":0.05 #QUAST QC: percent GC within +-($thisvalue) percent in reference to reference percent GC will pass the QC 
+        "genome_fraction_percent_cutoff":0.90 #QUAST QC: genome_fraction_percent less than ($thisvalue) will pass the QC
+        "busco_complete_single_cutoff":0.90 #BUSCO QC: complete single genes greater than ($thisvalue) percent will pass the QC
+        "busco_complete_duplicate_cutoff":0.10 #BUSCO QC: complete duplicate genes less than ($thisvalue) percent will pass the QC
     }
     
     print(str(datetime.datetime.now()) + "\n\nID: " + ID + "\nR1: " + R1 + "\nR2: " + R2)

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -297,21 +297,10 @@ def main():
     1. total length vs reference length +-10%
     2. percent gc versus reference percent gc +- 5%
     3. genome fraction percent > 90
-    '''
-    print("QUAST")
-    
-    if (float(quastResults["total_length"]) <= float(quastResults["reference_length"]) * (1 + float(qc_cutoffs["quast_assembly_length_cutoff"])) and float(quastResults["total_length"]) >= float(quastResults["reference_length"]) * (1 - float(qc_cutoffs["quast_assembly_length_cutoff"]))): #check for condition 1
-        qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
-    if (float(quastResults["percent_GC"]) <= float(quastResults["reference_percent_GC"]) * (1+ float(qc_cutoffs["quast_percent_gc_cutoff"])) and float(quastResults["percent_GC"]) >= float(quastResults["reference_percent_GC"]) * (1 - float(qc_cutoffs["quast_percent_gc_cutoff"]))): #check for condition 2
-        qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
-    if (float(quastResults["genome_fraction_percent"]) >= int(qc_cutoffs["genome_fraction_percent_cutoff"])):
+    '''   
+    if ((float(quastResults["total_length"]) <= float(quastResults["reference_length"]) * (1 + float(qc_cutoffs["quast_assembly_length_cutoff"])) and float(quastResults["total_length"]) >= float(quastResults["reference_length"]) * (1 - float(qc_cutoffs["quast_assembly_length_cutoff"]))) and (float(quastResults["percent_GC"]) <= float(quastResults["reference_percent_GC"]) * (1+ float(qc_cutoffs["quast_percent_gc_cutoff"])) and float(quastResults["percent_GC"]) >= float(quastResults["reference_percent_GC"]) * (1 - float(qc_cutoffs["quast_percent_gc_cutoff"]))) and (float(quastResults["genome_fraction_percent"]) >= int(qc_cutoffs["genome_fraction_percent_cutoff"]))): 
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
 
-    for key,value in buscoResults.items():
-        print(str(key) + ": " + str(value))
-    for key,value in quastResults.items():
-        print(str(key) + ": " + str(value))
-        
     #print QC results to screen
     print("total bases: " + str(total_bp))
     print("expected genome size: " + str(expected_genome_size))

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -300,9 +300,6 @@ def main():
     '''
     print("QUAST")
     
-    for keys,values in quastResults:
-        print(keys + ": " +values)
-    
     if (float(quastResults["total_length"]) <= float(quastResults["reference_length"]) * (1 + float(qc_cutoffs["quast_assembly_length_cutoff"])) and float(quastResults["total_length"]) >= float(quastResults["reference_length"]) * (1 - float(qc_cutoffs["quast_assembly_length_cutoff"]))): #check for condition 1
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
     if (float(quastResults["percent_GC"]) <= float(quastResults["reference_percent_GC"]) * (1+ float(qc_cutoffs["quast_percent_gc_cutoff"])) and float(quastResults["percent_GC"]) >= float(quastResults["reference_percent_GC"]) * (1 - float(qc_cutoffs["quast_percent_gc_cutoff"]))): #check for condition 2
@@ -310,14 +307,17 @@ def main():
     if (float(quastResults["genome_fraction_percent"]) >= int(qc_cutoffs["genome_fraction_percent_cutoff"])):
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
 
-        
+    for key,value in buscoResults.items():
+        print(str(key)) + ": " + str(value))
+    for key,value in quastResults.items():
+        print(str(key)) + ": " + str(value))
         
     #print QC results to screen
     print("total bases: " + str(total_bp))
     print("expected genome size: " + str(expected_genome_size))
     print("coverage: " + str(coverage))
     print("")
-    for key,value in qc_verdicts:
+    for key,value in qc_verdicts.items():
         print (str(key) + ": " + str(value))
         
     '''

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -298,8 +298,10 @@ def main():
     2. percent gc versus reference percent gc +- 5%
     3. genome fraction percent > 90
     '''
-    for keys in quastResults:
-        print(keys)
+    print("QUAST")
+    
+    for keys,values in quastResults:
+        print(keys + ": " +values)
     
     if (float(quastResults["total_length"]) <= float(quastResults["reference_length"]) * (1 + float(qc_cutoffs["quast_assembly_length_cutoff"])) and float(quastResults["total_length"]) >= float(quastResults["reference_length"]) * (1 - float(qc_cutoffs["quast_assembly_length_cutoff"]))): #check for condition 1
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -308,9 +308,9 @@ def main():
         qc_verdicts["Acceptable_QUAST_Assembly_Metrics"] = True
 
     for key,value in buscoResults.items():
-        print(str(key)) + ": " + str(value))
+        print(str(key) + ": " + str(value))
     for key,value in quastResults.items():
-        print(str(key)) + ": " + str(value))
+        print(str(key) + ": " + str(value))
         
     #print QC results to screen
     print("total bases: " + str(total_bp))

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -278,7 +278,7 @@ def main():
     print("Parsing assembly results")
     #get the correct busco and quast result file to parse
     buscoPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".busco" + "/short_summary_" + ID + ".busco.txt")
-    quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
+    quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.txt")
     #populate the busco and quast result object
     buscoResults = result_parsers.parse_busco_result(buscoPath)
     quastResults = result_parsers.parse_quast_result(quastPath)

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -281,7 +281,7 @@ def main():
     quastPath = (outputDir + "/assembly_qc/" + ID + "/" + ID + ".quast" + "/report.tsv")
     #populate the busco and quast result object
     buscoResults = result_parsers.parse_busco_result(buscoPath)
-    quastResults = result_parsers.parse_busco_result(quastPath)
+    quastResults = result_parsers.parse_quast_result(quastPath)
     
     #assembly QC logic    
     '''

--- a/assembly/pipeline.py
+++ b/assembly/pipeline.py
@@ -126,13 +126,13 @@ def main():
     }
     
     qc_cutoffs = {
-        "mash_hits_genome_score_cutoff":300 #genome mash will include all hits with scores (top hit score - $thisvalue)
-        "mash_hits_plasmid_score_cutoff":100 #plasmid mash will include all hits with scores (top hit score - $thisvalue)
-        "coverage_cutoff":30 #sequencing coverage greater than ($thisvalue) will pass the QC
-        "quast_assembly_length_cutoff":0.10 #QUAST QC: assembly length within +-($thisvalue) percent in reference to reference length will pass the QC 
-        "quast_percent_gc_cutoff":0.05 #QUAST QC: percent GC within +-($thisvalue) percent in reference to reference percent GC will pass the QC 
-        "genome_fraction_percent_cutoff":0.90 #QUAST QC: genome_fraction_percent less than ($thisvalue) will pass the QC
-        "busco_complete_single_cutoff":0.90 #BUSCO QC: complete single genes greater than ($thisvalue) percent will pass the QC
+        "mash_hits_genome_score_cutoff":300, #genome mash will include all hits with scores (top hit score - $thisvalue)
+        "mash_hits_plasmid_score_cutoff":100, #plasmid mash will include all hits with scores (top hit score - $thisvalue)
+        "coverage_cutoff":30, #sequencing coverage greater than ($thisvalue) will pass the QC
+        "quast_assembly_length_cutoff":0.10, #QUAST QC: assembly length within +-($thisvalue) percent in reference to reference length will pass the QC 
+        "quast_percent_gc_cutoff":0.05, #QUAST QC: percent GC within +-($thisvalue) percent in reference to reference percent GC will pass the QC 
+        "genome_fraction_percent_cutoff":0.90, #QUAST QC: genome_fraction_percent less than ($thisvalue) will pass the QC
+        "busco_complete_single_cutoff":0.90, #BUSCO QC: complete single genes greater than ($thisvalue) percent will pass the QC
         "busco_complete_duplicate_cutoff":0.10 #BUSCO QC: complete duplicate genes less than ($thisvalue) percent will pass the QC
     }
     

--- a/assembly/pipeline_assembly.sh
+++ b/assembly/pipeline_assembly.sh
@@ -64,7 +64,7 @@ assembly_output_dir="${assembly_dir}/${sample_id}"
 
 source activate shovill-1.0.1
 
-shovill \
+#shovill \
     --mincov 3 \
     --minlen 500 \
     --force \
@@ -90,7 +90,7 @@ source activate quast-4.6.3
 
 #run quast on assembled genome
 mkdir -p "${qc_dir}"/"${sample_id}"
-quast \
+#quast \
     "${contigs_dir}/${sample_id}.fa" \
     -R "${reference_genome}" \
     -o "${qc_dir}/${sample_id}/${sample_id}.quast" \

--- a/assembly/pipeline_assembly.sh
+++ b/assembly/pipeline_assembly.sh
@@ -64,16 +64,16 @@ assembly_output_dir="${assembly_dir}/${sample_id}"
 
 source activate shovill-1.0.1
 
-#shovill \
-#    --mincov 3 \
-#    --minlen 500 \
-#    --force \
-#    --R1 "${reads1_file}" \
-#    --R2 "${reads2_file}" \
-#    --cpus "${threads}" \
-#    --ram "${ram}" \
-#    --tmpdir "${temp_dir}" \
-#    --outdir "${assembly_output_dir}"
+shovill \
+    --mincov 3 \
+    --minlen 500 \
+    --force \
+    --R1 "${reads1_file}" \
+    --R2 "${reads2_file}" \
+    --cpus "${threads}" \
+    --ram "${ram}" \
+    --tmpdir "${temp_dir}" \
+    --outdir "${assembly_output_dir}"
 
 source deactivate
 
@@ -90,11 +90,11 @@ source activate quast-4.6.3
 
 #run quast on assembled genome
 mkdir -p "${qc_dir}"/"${sample_id}"
-#quast \
-#    "${contigs_dir}/${sample_id}.fa" \
-#    -R "${reference_genome}" \
-#    -o "${qc_dir}/${sample_id}/${sample_id}.quast" \
-#    --threads "${threads}"
+quast \
+    "${contigs_dir}/${sample_id}.fa" \
+    -R "${reference_genome}" \
+    -o "${qc_dir}/${sample_id}/${sample_id}.quast" \
+    --threads "${threads}"
 
 source deactivate
 
@@ -102,7 +102,7 @@ source activate busco-3.0.2
 
 cd "${qc_dir}"/"${sample_id}"
 run_busco \
-    -i "../../../${contigs_dir}/${sample_id}.fa" \
+    -i "${contigs_dir}/${sample_id}.fa" \
     -o "${sample_id}.busco" \
     -l "${busco_db}" \
     -m genome \

--- a/assembly/pipeline_assembly.sh
+++ b/assembly/pipeline_assembly.sh
@@ -65,15 +65,15 @@ assembly_output_dir="${assembly_dir}/${sample_id}"
 source activate shovill-1.0.1
 
 #shovill \
-    --mincov 3 \
-    --minlen 500 \
-    --force \
-    --R1 "${reads1_file}" \
-    --R2 "${reads2_file}" \
-    --cpus "${threads}" \
-    --ram "${ram}" \
-    --tmpdir "${temp_dir}" \
-    --outdir "${assembly_output_dir}"
+#    --mincov 3 \
+#    --minlen 500 \
+#    --force \
+#    --R1 "${reads1_file}" \
+#    --R2 "${reads2_file}" \
+#    --cpus "${threads}" \
+#    --ram "${ram}" \
+#    --tmpdir "${temp_dir}" \
+#    --outdir "${assembly_output_dir}"
 
 source deactivate
 
@@ -91,10 +91,10 @@ source activate quast-4.6.3
 #run quast on assembled genome
 mkdir -p "${qc_dir}"/"${sample_id}"
 #quast \
-    "${contigs_dir}/${sample_id}.fa" \
-    -R "${reference_genome}" \
-    -o "${qc_dir}/${sample_id}/${sample_id}.quast" \
-    --threads "${threads}"
+#    "${contigs_dir}/${sample_id}.fa" \
+#    -R "${reference_genome}" \
+#    -o "${qc_dir}/${sample_id}/${sample_id}.quast" \
+#    --threads "${threads}"
 
 source deactivate
 


### PR DESCRIPTION
- fix issue 15 https://github.com/Public-Health-Bioinformatics/cpo-pipeline/issues/15
- put all the different cutoffs used for QC metrics into a dictionary for better organization and downstream modifications
- script for starting busco no longer requires the '../../../' for proper output directory all of a sudden. No idea why...